### PR TITLE
remove platform attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,20 +9,19 @@ code by adding this replacement.
 
 ### usage
 
-You can install it via Composer by typing:
-
-```sh
-$ composer require rubo77/php-mysql-fix:dev-master
-```
-
-and remembering to also add the `files` section as indicated below:
+You can install it via Composer adding this to your `composer.json`:
 
 ```json
 {
     "name": "<vendor>/<project>",
-    "minimum-stability": "dev",
+    "repositories" : [
+        {
+            "type": "vcs",
+            "url": "https://github.com/rubo77/php-mysql-fix"
+        }
+    ],
     "require": {
-        "rubo77/php-mysql-fix": "dev-master"
+        "rubo77/php-mysql-fix": "^1.0"
     },
     "autoload": {
         "files": [
@@ -30,6 +29,13 @@ and remembering to also add the `files` section as indicated below:
         ]
     }
 }
+
+```
+
+and then typing:
+
+```sh
+$ composer update
 ```
 
 Alternatively you can manually download and include the file at the top of your PHP script:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can install it via Composer adding this to your `composer.json`:
         }
     ],
     "require": {
-        "rubo77/php-mysql-fix": "^1.0"
+        "rubo77/php-mysql-fix": "^4.0"
     },
     "autoload": {
         "files": [

--- a/README.md
+++ b/README.md
@@ -5,14 +5,39 @@ A replacement for all mysql functions with mysqli equivalents.
 Be aware, that this is just a workaround to fix-up some old code and the resulting project 
 will be more vulnerable than if you use the recommended newer mysqli-functions instead.
 So only If you are sure that this is not setting your server at risk, you can fix your old
-code by adding this line at the beginning of your old code:
+code by adding this replacement.
 
 ### usage
 
-Download and include the file in the top of your PHP script:
+You can install it via Composer by typing:
 
-    <?php
-    include_once('fix_mysql.inc.php');
+```sh
+$ composer require rubo77/php-mysql-fix:dev-master
+```
+
+and remembering to also add the `files` section as indicated below:
+
+```json
+{
+    "name": "<vendor>/<project>",
+    "minimum-stability": "dev",
+    "require": {
+        "rubo77/php-mysql-fix": "dev-master"
+    },
+    "autoload": {
+        "files": [
+            "vendor/rubo77/php-mysql-fix/fix_mysql.inc.php"
+        ]
+    }
+}
+```
+
+Alternatively you can manually download and include the file at the top of your PHP script:
+
+```php
+<?php
+require 'fix_mysql.inc.php';
+```
 
 ### discussion
 

--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,6 @@
     "description" : "A replacement for all mysql functions with mysqli equivalents.",
     "license": "MIT",
     "config" : {
-        "platform": {
-            "php": "7.0"
-        },
         "sort-packages": true
     },
     "autoload": {


### PR DESCRIPTION
see https://github.com/rubo77/php-mysql-fix/pull/11

In the README I specified to use `dev-master` because the package has no releases, but it would be better to create a `v1.0.0` version as indicated here https://lornajane.net/posts/2015/relying-on-a-dev-master-dependency-in-composer.

Once the version has been created, any reference to `dev-master` and `"minimum-stability": "dev"` can be removed:

```sh
$ composer require rubo77/php-mysql-fix
```

```json
{
    "name": "<vendor>/<project>",
    "require": {
        "rubo77/php-mysql-fix": "^1.0"
    },
    "autoload": {
        "files": [
            "vendor/rubo77/php-mysql-fix/fix_mysql.inc.php"
        ]
    }
}
```


